### PR TITLE
fixup! alsa-info: lots of mostly syntactic changes

### DIFF
--- a/alsa-info/alsa-info.sh
+++ b/alsa-info/alsa-info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 SCRIPT_VERSION=0.4.64
 CHANGELOG="http://www.alsa-project.org/alsa-info.sh.changelog"
@@ -34,70 +34,66 @@ PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin
 BGTITLE="ALSA-Info v $SCRIPT_VERSION"
 PASTEBINKEY="C9cRIO8m/9y8Cs0nVs0FraRx7U0pHsuc"
 
-WGET=$(which wget 2>/dev/null | sed 's|^[^/]*||' 2>/dev/null)
-REQUIRES="mktemp grep pgrep whereis ping awk date uname cat dmesg amixer alsactl"
+WGET=$(command -v wget)
+REQUIRES="mktemp grep pgrep ping date uname cat dmesg amixer alsactl"
 
 #
 # Define some simple functions
 #
 
 pbcheck() {
-	[[ $UPLOAD = "no" ]] && return
+	[ "$UPLOAD" = "no" ] && return
 
-	if [[ -z $PASTEBIN ]]; then
-		[[ $(ping -c1 www.alsa-project.org) ]] || KEEP_FILES="yes" UPLOAD="no" PBERROR="yes"
+	if [ -z "$PASTEBIN" ]; then
+		ping -qc1 www.alsa-project.org || KEEP_FILES="yes" UPLOAD="no" PBERROR="yes"
 	else
-		[[ $(ping -c1 www.pastebin.ca) ]] || KEEP_FILES="yes" UPLOAD="no" PBERROR="yes"
+		ping -qc1 www.pastebin.ca || KEEP_FILES="yes" UPLOAD="no" PBERROR="yes"
 	fi
 }
 
 update() {
-	test -z "$WGET" -o ! -x "$WGET" && return
+	[ -x "$WGET" ] || return
 
-	SHFILE=$(mktemp -t alsa-info.XXXXXXXXXX) || exit 1
-	wget -O $SHFILE "http://www.alsa-project.org/alsa-info.sh" >/dev/null 2>&1
-	REMOTE_VERSION=$(grep SCRIPT_VERSION $SHFILE | head -n1 | sed 's/.*=//')
-	if [ -s "$SHFILE" -a "$REMOTE_VERSION" != "$SCRIPT_VERSION" ]; then
-		if [[ -n $DIALOG ]]
-		then
+	SHFILE="$(mktemp -t alsa-info.XXXXXXXXXX)" || exit 1
+	wget -O "$SHFILE" "http://www.alsa-project.org/alsa-info.sh" >/dev/null 2>&1
+	REMOTE_VERSION="$(sed -n 's/^SCRIPT_VERSION=//p' "$SHFILE")"
+	if [ -s "$SHFILE" ] && [ "$REMOTE_VERSION" != "$SCRIPT_VERSION" ]; then
+		if [ -n "$DIALOG" ]; then
 			OVERWRITE=
-			if [ -w $0 ]; then
+			if [ -w "$0" ]; then
 				dialog --yesno "Newer version of ALSA-Info has been found\n\nDo you wish to install it?\nNOTICE: The original file $0 will be overwritten!" 0 0
 				DIALOG_EXIT_CODE=$?
-				if [[ $DIALOG_EXIT_CODE = 0 ]]; then
-				  OVERWRITE=yes
-				fi
+				[ "$DIALOG_EXIT_CODE" = 0 ] && OVERWRITE=yes
 			fi
 			if [ -z "$OVERWRITE" ]; then
 				dialog --yesno "Newer version of ALSA-Info has been found\n\nDo you wish to download it?" 0 0
 				DIALOG_EXIT_CODE=$?
 			fi
-			if [[ $DIALOG_EXIT_CODE = 0 ]]
-			then
+			if [ "$DIALOG_EXIT_CODE" = 0 ]; then
 				echo "Newer version detected: $REMOTE_VERSION"
 				echo "To view the ChangeLog, please visit $CHANGELOG"
 				if [ "$OVERWRITE" = "yes" ]; then
-					cp $SHFILE $0
+					cp "$SHFILE" "$0"
 					echo "ALSA-Info script has been updated to v $REMOTE_VERSION"
 					echo "Please re-run the script"
-					rm $SHFILE 2>/dev/null
+					rm -f "$SHFILE"
 				else
 					echo "ALSA-Info script has been downloaded as $SHFILE."
 					echo "Please re-run the script from new location."
 				fi
 				exit
 			else
-				rm $SHFILE 2>/dev/null
+				rm -f "$SHFILE"
 			fi
 		else
 			echo "Newer version detected: $REMOTE_VERSION"
 			echo "To view the ChangeLog, please visit $CHANGELOG"
-			if [ -w $0 ]; then
+			if [ -w "$0" ]; then
 				echo "The original file $0 will be overwritten!"
-				echo -n "If you do not like to proceed, press Ctrl-C now.." ; read inp
-				cp $SHFILE $0
+				printf "If you do not like to proceed, press Ctrl-C now.."; read -r _
+				cp "$SHFILE" "$0"
 				echo "ALSA-Info script has been updated. Please re-run it."
-				rm $SHFILE 2>/dev/null
+				rm -f "$SHFILE"
 			else
 				echo "ALSA-Info script has been downloaded $SHFILE."
 				echo "Please, re-run it from new location."
@@ -105,148 +101,146 @@ update() {
 			exit
 		fi
 	else
-		rm $SHFILE 2>/dev/null
+		rm -f "$SHFILE"
 	fi
 }
 
 cleanup() {
-	if [ -n "$TEMPDIR" -a "$KEEP_FILES" != "yes" ]; then
-		rm -rf "$TEMPDIR" 2>/dev/null
+	if [ -n "$TEMPDIR" ] && [ "$KEEP_FILES" != "yes" ]; then
+		rm -rf "$TEMPDIR"
 	fi
-	test -n "$KEEP_OUTPUT" || rm -f "$NFILE"
+	[ -n "$KEEP_OUTPUT" ] || rm -f "$NFILE"
 }
-
 
 withaplay() {
-        echo "!!Aplay/Arecord output" >> $FILE
-        echo "!!--------------------" >> $FILE
-        echo "" >> $FILE
-       	echo "APLAY" >> $FILE
-	echo "" >> $FILE 
-	aplay -l >> $FILE 2>&1
-        echo "" >> $FILE
-       	echo "ARECORD" >> $FILE
-	echo "" >> $FILE
-	arecord -l >> $FILE 2>&1
-	echo "" >> $FILE
-}
+	echo "!!Aplay/Arecord output"
+	echo "!!--------------------"
+	echo ""
+	echo "APLAY"
+	echo ""
+	aplay -l 2>&1
+	echo ""
+	echo "ARECORD"
+	echo ""
+	arecord -l 2>&1
+	echo ""
+} >> "$FILE"
 
 withlsmod() {
-	echo "!!All Loaded Modules" >> $FILE
-	echo "!!------------------" >> $FILE
-	echo "" >> $FILE
-	lsmod | awk '{print $1}' >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
-}
+	echo "!!All Loaded Modules"
+	echo "!!------------------"
+	echo ""
+	lsmod | while read -r mod _; do
+		echo "$mod"
+	done
+	echo ""
+	echo ""
+} >> "$FILE"
 
 withamixer() {
-        echo "!!Amixer output" >> $FILE
-        echo "!!-------------" >> $FILE
-        echo "" >> $FILE
-	for i in $(grep "]: " /proc/asound/cards | awk -F ' ' '{ print $1 }') ; do
-		CARD_NAME=$(grep "^ *$i " $TEMPDIR/alsacards.tmp | awk '{ print $2 }')
-		echo "!!-------Mixer controls for card $i $CARD_NAME]" >> $FILE
-		echo "" >>$FILE
-		amixer -c$i info >> $FILE 2>&1
-		amixer -c$i >> $FILE 2>&1
-		echo "" >> $FILE
+	echo "!!Amixer output"
+	echo "!!-------------"
+	echo ""
+	sed -n '/]: /s/^[[:space:]]\([0-9]\+\).*/\1/p' /proc/asound/cards | while read -r i; do
+		CARD_NAME=$(sed -n "s/^ *$i \([^ ]\+\).*/\1/p" "$TEMPDIR/alsacards.tmp")
+		echo "!!-------Mixer controls for card $i $CARD_NAME]"
+		echo ""
+		amixer -c"$i" info 2>&1
+		amixer -c"$i" 2>&1
+		echo ""
 	done
-	echo "" >> $FILE
-}
+	echo ""
+} >> "$FILE"
 
 withalsactl() {
-	echo "!!Alsactl output" >> $FILE
-        echo "!!--------------" >> $FILE
-        echo "" >> $FILE
-	alsactl -f $TEMPDIR/alsactl.tmp store
-	echo "--startcollapse--" >> $FILE
-	cat $TEMPDIR/alsactl.tmp >> $FILE
-	echo "--endcollapse--" >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
-}
+	echo "!!Alsactl output"
+	echo "!!--------------"
+	echo ""
+	alsactl -f "$TEMPDIR/alsactl.tmp" store
+	echo "--startcollapse--"
+	cat "$TEMPDIR/alsactl.tmp"
+	echo "--endcollapse--"
+	echo ""
+	echo ""
+} >> "$FILE"
 
 withdevices() {
-        echo "!!ALSA Device nodes" >> $FILE
-        echo "!!-----------------" >> $FILE
-        echo "" >> $FILE
-        ls -la /dev/snd/* >> $FILE
-        echo "" >> $FILE
-        echo "" >> $FILE
-}
+	echo "!!ALSA Device nodes"
+	echo "!!-----------------"
+	echo ""
+	ls -la /dev/snd/*
+	echo ""
+	echo ""
+} >> "$FILE"
 
 withconfigs() {
-if [[ -e $HOME/.asoundrc ]] || [[ -e /etc/asound.conf ]] || [[ -e $HOME/.asoundrc.asoundconf ]]; then
-        echo "!!ALSA configuration files" >> $FILE
-        echo "!!------------------------" >> $FILE
-        echo "" >> $FILE
+	if [ -e "$HOME/.asoundrc" ] || [ -e /etc/asound.conf ] || [ -e "$HOME/.asoundrc.asoundconf" ]; then
+		echo "!!ALSA configuration files"
+		echo "!!------------------------"
+		echo ""
 
-        #Check for ~/.asoundrc
-        if [[ -e $HOME/.asoundrc ]]
-        then
-                echo "!!User specific config file (~/.asoundrc)" >> $FILE
-                echo "" >> $FILE
-                cat $HOME/.asoundrc >> $FILE
-                echo "" >> $FILE
-                echo "" >> $FILE
-        fi
-	#Check for .asoundrc.asoundconf (seems to be Ubuntu specific)
-	if [[ -e $HOME/.asoundrc.asoundconf ]]
-	then
-		echo "!!asoundconf-generated config file" >> $FILE
-		echo "" >> $FILE
-		cat $HOME/.asoundrc.asoundconf >> $FILE
-		echo "" >> $FILE
-		echo "" >> $FILE
+		#Check for ~/.asoundrc
+		if [ -e "$HOME/.asoundrc" ]; then
+			echo "!!User specific config file (~/.asoundrc)"
+			echo ""
+			cat "$HOME/.asoundrc"
+			echo ""
+			echo ""
+		fi
+		#Check for .asoundrc.asoundconf (seems to be Ubuntu specific)
+		if [ -e "$HOME/.asoundrc.asoundconf" ]; then
+			echo "!!asoundconf-generated config file"
+			echo ""
+			cat "$HOME/.asoundrc.asoundconf"
+			echo ""
+			echo ""
+		fi
+		#Check for /etc/asound.conf
+		if [ -e /etc/asound.conf ]; then
+			echo "!!System wide config file (/etc/asound.conf)"
+			echo ""
+			cat /etc/asound.conf
+			echo ""
+			echo ""
+		fi
 	fi
-        #Check for /etc/asound.conf
-        if [[ -e /etc/asound.conf ]]
-        then
-                echo "!!System wide config file (/etc/asound.conf)" >> $FILE
-                echo "" >> $FILE
-                cat /etc/asound.conf >> $FILE
-                echo "" >> $FILE
-                echo "" >> $FILE
-        fi
-fi
-}
+} >> "$FILE"
 
 withsysfs() {
-    local i f
-    local printed=""
-    for i in /sys/class/sound/*; do
+	printed=''
+
+	for i in /sys/class/sound/*; do
 	case "$i" in
-	    */hwC?D?)
-		if [ -f $i/init_pin_configs ]; then
-		    if [ -z "$printed" ]; then
-			echo "!!Sysfs Files" >> $FILE
-			echo "!!-----------" >> $FILE
-			echo "" >> $FILE
-		    fi
-		    for f in init_pin_configs driver_pin_configs user_pin_configs init_verbs hints; do
-			echo "$i/$f:" >> $FILE
-			cat $i/$f >> $FILE
-			echo >> $FILE
-		    done
-		    printed=yes
-		fi
-		;;
-	    esac
-    done
-    if [ -n "$printed" ]; then
-	echo "" >> $FILE
-    fi
-}
+		*/hwC?D?)
+			if [ -f "$i/init_pin_configs" ]; then
+				if [ -z "$printed" ]; then
+					echo "!!Sysfs Files"
+					echo "!!-----------"
+					echo ""
+				fi
+				for f in init_pin_configs driver_pin_configs user_pin_configs init_verbs hints; do
+					echo "$i/$f:"
+					cat "$i/$f"
+					echo
+				done
+				printed=yes
+			fi
+			;;
+		esac
+	done
+	if [ -n "$printed" ]; then
+		echo ""
+	fi
+} >> "$FILE"
 
 withdmesg() {
-	echo "!!ALSA/HDA dmesg" >> $FILE
-	echo "!!--------------" >> $FILE
-	echo "" >> $FILE
-	dmesg | grep -C1 -E 'ALSA|HDA|HDMI|snd[_-]|sound|hda.codec|hda.intel' >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
-}
+	echo "!!ALSA/HDA dmesg"
+	echo "!!--------------"
+	echo ""
+	dmesg | grep -C1 -E 'ALSA|HDA|HDMI|snd[_-]|sound|hda.codec|hda.intel'
+	echo ""
+	echo ""
+} >> "$FILE"
 
 withall() {
 	withdevices
@@ -261,15 +255,15 @@ withall() {
 }
 
 get_alsa_library_version() {
-	ALSA_LIB_VERSION=$(grep VERSION_STR /usr/include/alsa/version.h 2>/dev/null | awk '{ print $3 }' | sed 's/"//g')
+	ALSA_LIB_VERSION="$(sed -n 's/.*VERSION_STR[[:space:]]*"\(.*\)"/\1/p' /usr/include/alsa/version.h)"
 
 	if [ -z "$ALSA_LIB_VERSION" ]; then
 		if [ -f /etc/lsb-release ]; then
 			. /etc/lsb-release
 			case "$DISTRIB_ID" in
 				Ubuntu)
-					if which dpkg > /dev/null ; then
-						ALSA_LIB_VERSION=$(dpkg -l libasound2 | tail -1 | awk '{ print $3 }' | cut -f 1 -d -)
+					if command -v dpkg > /dev/null ; then
+						ALSA_LIB_VERSION=$(dpkg -l libasound2 | sed -n '$s/[^[:space:]]*[[:space:]]*[^[:space:]]*[[:space:]]*\([^[:space:]]*\).*/\1/p')
 					fi
 
 					if [ "$ALSA_LIB_VERSION" = "<none>" ]; then
@@ -282,8 +276,8 @@ get_alsa_library_version() {
 					;;
 			esac
 		elif [ -f /etc/debian_version ]; then
-			if which dpkg > /dev/null ; then
-				ALSA_LIB_VERSION=$(dpkg -l libasound2 | tail -1 | awk '{ print $3 }' | cut -f 1 -d -)
+			if command -v dpkg >/dev/null ; then
+				ALSA_LIB_VERSION=$(dpkg -l libasound2 | sed -n '$s/[^[:space:]]*[[:space:]]*[^[:space:]]*[[:space:]]*\([^[:space:]]*\).*/\1/p')
 			fi
 
 			if [ "$ALSA_LIB_VERSION" = "<none>" ]; then
@@ -296,23 +290,22 @@ get_alsa_library_version() {
 
 # Basic requires
 for prg in $REQUIRES; do
-  t=$(which $prg 2> /dev/null)
-  if test -z "$t"; then
-    echo "This script requires $prg utility to continue."
-    exit 1
-  fi
+	if ! command -v "$prg" >/dev/null; then
+		echo "This script requires $prg utility to continue."
+		exit 1
+	fi
 done
 
 # Run checks to make sure the programs we need are installed.
-LSPCI=$(which lspci 2>/dev/null | sed 's|^[^/]*||' 2>/dev/null);
-TPUT=$(which tput 2>/dev/null | sed 's|^[^/]*||' 2>/dev/null);
-DIALOG=$(which dialog 2>/dev/null | sed 's|^[^/]*||' 2>/dev/null);
+LSPCI="$(command -v lspci)"
+TPUT="$(command -v tput)"
+DIALOG="$(command -v dialog)"
 
 # Check to see if sysfs is enabled in the kernel. We'll need this later on
-SYSFS=$(mount | grep sysfs | awk '{ print $3 }');
+SYSFS=$(mount | sed -n 's/^sysfs on \([^ ]*\) type.*/\1/p');
 
 # Check modprobe config files for sound related options
-SNDOPTIONS=$(modprobe -c|sed -n 's/^options \(snd[-_][^ ]*\)/\1:/p')
+SNDOPTIONS=$(modprobe -c | sed -n 's/^options \(snd[-_][^ ]*\)/\1:/p')
 
 KEEP_OUTPUT=
 NFILE=""
@@ -324,42 +317,42 @@ PROCEED="yes"
 UPLOAD="ask"
 REPEAT=""
 while [ -z "$REPEAT" ]; do
-REPEAT="no"
-case "$1" in
-	--update|--help|--about)
-		WELCOME="no"
-		PROCEED="no"
-		;;
-	--upload)
-		UPLOAD="yes"
-		WELCOME="no"
-		;;
-	--no-upload)
-		UPLOAD="no"
-		WELCOME="no"
-		;;
-	--pastebin)
-		PASTEBIN="yes"
-		WWWSERVICE="pastebin"
-		;;
-	--no-dialog)
-		DIALOG=""
-		REPEAT=""
-		shift
-		;;
-	--stdout)
-		DIALOG=""
-		UPLOAD="no"
-		WELCOME="no"
-		TOSTDOUT="yes"
-		;;
-esac
+	REPEAT="no"
+	case "$1" in
+		--update|--help|--about)
+			WELCOME="no"
+			PROCEED="no"
+			;;
+		--upload)
+			UPLOAD="yes"
+			WELCOME="no"
+			;;
+		--no-upload)
+			UPLOAD="no"
+			WELCOME="no"
+			;;
+		--pastebin)
+			PASTEBIN="yes"
+			WWWSERVICE="pastebin"
+			;;
+		--no-dialog)
+			DIALOG=""
+			REPEAT=""
+			shift
+			;;
+		--stdout)
+			DIALOG=""
+			UPLOAD="no"
+			WELCOME="no"
+			TOSTDOUT="yes"
+			;;
+	esac
 done
 
 
 #Script header output.
 if [ "$WELCOME" = "yes" ]; then
-greeting_message="\
+	greeting_message="\
 
 This script visits the following commands/files to collect diagnostic
 information about your ALSA installation and sound related hardware.
@@ -376,15 +369,15 @@ information about your ALSA installation and sound related hardware.
 
 See '$0 --help' for command line options.
 "
-if [ -n "$DIALOG" ]; then
-	dialog  --backtitle "$BGTITLE" \
-		--title "ALSA-Info script v $SCRIPT_VERSION" \
-		--msgbox "$greeting_message" 20 80
-else
-	echo "ALSA Information Script v $SCRIPT_VERSION"
-	echo "--------------------------------"
-	echo "$greeting_message"
-fi # dialog
+	if [ -n "$DIALOG" ]; then
+		dialog  --backtitle "$BGTITLE" \
+			--title "ALSA-Info script v $SCRIPT_VERSION" \
+			--msgbox "$greeting_message" 20 80
+	else
+		echo "ALSA Information Script v $SCRIPT_VERSION"
+		echo "--------------------------------"
+		echo "$greeting_message"
+	fi # dialog
 fi # WELCOME
 
 # Set the output file
@@ -397,279 +390,283 @@ fi
 trap cleanup 0
 
 if [ "$PROCEED" = "yes" ]; then
-
-if [ -z "$LSPCI" ]; then
-	if [ -d /sys/bus/pci ]; then
+	if [ -z "$LSPCI" ] && [ -d /sys/bus/pci ]; then
 		echo "This script requires lspci. Please install it, and re-run this script."
 		exit 0
 	fi
-fi
 
-# Fetch the info and store in temp files/variables
-TSTAMP=$(LANG=C TZ=UTC date)
-DISTRO=$(grep -ihs "buntu\|SUSE\|Fedora\|PCLinuxOS\|MEPIS\|Mandriva\|Debian\|Damn\|Sabayon\|Slackware\|KNOPPIX\|Gentoo\|Zenwalk\|Mint\|Kubuntu\|FreeBSD\|Puppy\|Freespire\|Vector\|Dreamlinux\|CentOS\|Arch\|Xandros\|Elive\|SLAX\|Red\|BSD\|KANOTIX\|Nexenta\|Foresight\|GeeXboX\|Frugalware\|64\|SystemRescue\|Novell\|Solaris\|BackTrack\|KateOS\|Pardus" /etc/{issue,*release,*version})
-KERNEL_VERSION=$(uname -r)
-KERNEL_PROCESSOR=$(uname -p)
-KERNEL_MACHINE=$(uname -m)
-KERNEL_OS=$(uname -o)
-[[ $(uname -v | grep SMP) ]] && KERNEL_SMP="Yes" || KERNEL_SMP="No"
-ALSA_DRIVER_VERSION=$(cat /proc/asound/version | head -n1 | awk '{ print $7 }' | sed 's/\.$//')
-get_alsa_library_version
-ALSA_UTILS_VERSION=$(amixer -v | awk '{ print $3 }')
+	# Fetch the info and store in temp files/variables
+	TSTAMP=$(LANG=C TZ=UTC date)
+	DISTRO=$(grep -Eihs "buntu|SUSE|Fedora|PCLinuxOS|MEPIS|Mandriva|Debian|Damn|Sabayon|Slackware|KNOPPIX|Gentoo|Zenwalk|Mint|Kubuntu|FreeBSD|Puppy|Freespire|Vector|Dreamlinux|CentOS|Arch|Xandros|Elive|SLAX|Red|BSD|KANOTIX|Nexenta|Foresight|GeeXboX|Frugalware|64|SystemRescue|Novell|Solaris|BackTrack|KateOS|Pardus" /etc/issue /etc/*release /etc/*version)
+	KERNEL_VERSION=$(uname -r)
+	KERNEL_PROCESSOR=$(uname -p 2>/dev/null) # silence error because -p isn't POSIX
+	KERNEL_MACHINE=$(uname -m)
+	KERNEL_OS=$(uname -o 2>/dev/null) # silence error because -o isn't POSIX
+	case "$(uname -v)" in
+		*SMP*)  KERNEL_SMP="Yes";;
+		*)		KERNEL_SMP="No";;
+	esac
+	ALSA_DRIVER_VERSION=$(sed -n '0s/.* \([^ ]*\)\.$/\1/p' /proc/asound/version)
+	get_alsa_library_version
+	ALSA_UTILS_VERSION=$(amixer -v | sed 's/amixer version //')
 
-ESDINST=$(which esd 2>/dev/null| sed 's|^[^/]*||' 2>/dev/null)
-PAINST=$(which pulseaudio 2>/dev/null| sed 's|^[^/]*||' 2>/dev/null)
-ARTSINST=$(which artsd 2>/dev/null| sed 's|^[^/]*||' 2>/dev/null)
-JACKINST=$(which jackd 2>/dev/null| sed 's|^[^/]*||' 2>/dev/null)
-ROARINST=$(which roard 2>/dev/null| sed 's|^[^/]*||' 2>/dev/null)
-DMIDECODE=$(which dmidecode 2>/dev/null| sed 's|^[^/]*||' 2>/dev/null)
+	ESDINST=$(command -v esd)
+	PAINST=$(command -v pulseaudio)
+	ARTSINST=$(command -v artsd)
+	JACKINST=$(command -v jackd)
+	ROARINST=$(command -v roard)
+	DMIDECODE=$(command -v dmidecode)
 
-#Check for DMI data
-if [ -d /sys/class/dmi/id ]; then
-    # No root privileges are required when using sysfs method
-    DMI_SYSTEM_MANUFACTURER=$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null)
-    DMI_SYSTEM_PRODUCT_NAME=$(cat /sys/class/dmi/id/product_name 2>/dev/null)
-    DMI_SYSTEM_PRODUCT_VERSION=$(cat /sys/class/dmi/id/product_version 2>/dev/null)
-    DMI_SYSTEM_FIRMWARE_VERSION=$(cat /sys/class/dmi/id/bios_version 2>/dev/null)
-    DMI_BOARD_VENDOR=$(cat /sys/class/dmi/id/board_vendor 2>/dev/null)
-    DMI_BOARD_NAME=$(cat /sys/class/dmi/id/board_name 2>/dev/null)
-elif [ -x $DMIDECODE ]; then
-    DMI_SYSTEM_MANUFACTURER=$($DMIDECODE -s system-manufacturer 2>/dev/null)
-    DMI_SYSTEM_PRODUCT_NAME=$($DMIDECODE -s system-product-name 2>/dev/null)
-    DMI_SYSTEM_PRODUCT_VERSION=$($DMIDECODE -s system-version 2>/dev/null)
-    DMI_SYSTEM_FIRMWARE_VERSION=$($DMIDECODE -s bios-version 2>/dev/null)
-    DMI_BOARD_VENDOR=$($DMIDECODE -s baseboard-manufacturer 2>/dev/null)
-    DMI_BOARD_NAME=$($DMIDECODE -s baseboard-product-name 2>/dev/null)
-fi
+	#Check for DMI data
+	if [ -d /sys/class/dmi/id ]; then
+		# No root privileges are required when using sysfs method
+		DMI_SYSTEM_MANUFACTURER=$(cat /sys/class/dmi/id/sys_vendor)
+		DMI_SYSTEM_PRODUCT_NAME=$(cat /sys/class/dmi/id/product_name)
+		DMI_SYSTEM_PRODUCT_VERSION=$(cat /sys/class/dmi/id/product_version)
+		DMI_SYSTEM_FIRMWARE_VERSION=$(cat /sys/class/dmi/id/bios_version)
+		DMI_BOARD_VENDOR=$(cat /sys/class/dmi/id/board_vendor)
+		DMI_BOARD_NAME=$(cat /sys/class/dmi/id/board_name)
+	elif [ -x "$DMIDECODE" ]; then
+		DMI_SYSTEM_MANUFACTURER=$("$DMIDECODE" -s system-manufacturer)
+		DMI_SYSTEM_PRODUCT_NAME=$("$DMIDECODE" -s system-product-name)
+		DMI_SYSTEM_PRODUCT_VERSION=$("$DMIDECODE" -s system-version)
+		DMI_SYSTEM_FIRMWARE_VERSION=$("$DMIDECODE" -s bios-version)
+		DMI_BOARD_VENDOR=$("$DMIDECODE" -s baseboard-manufacturer)
+		DMI_BOARD_NAME=$("$DMIDECODE" -s baseboard-product-name)
+	fi 2>/dev/null
 
-# Check for ACPI device status
-if [ -d /sys/bus/acpi/devices ]; then
-    for f in /sys/bus/acpi/devices/*/status; do
-	ACPI_STATUS=$(cat $f 2>/dev/null);
-	if [[ "$ACPI_STATUS" -ne 0 ]]; then
-	    echo $f $'\t' $ACPI_STATUS >>$TEMPDIR/acpidevicestatus.tmp;
+	# Check for ACPI device status
+	if [ -d /sys/bus/acpi/devices ]; then
+		for f in /sys/bus/acpi/devices/*/status; do
+			read -r ACPI_STATUS < "$f"
+			if [ "$ACPI_STATUS" -ne 0 ]; then
+				printf '%s \t %s\n' "$f" "$ACPI_STATUS" >>"$TEMPDIR/acpidevicestatus.tmp"
+			fi
+		done
 	fi
-    done
-fi
 
-cat /proc/asound/modules 2>/dev/null | awk '{ print $2 }' > $TEMPDIR/alsamodules.tmp
-cat /proc/asound/cards > $TEMPDIR/alsacards.tmp
-if [[ ! -z "$LSPCI" ]]; then
-  lspci | grep -i "multi\|audio">$TEMPDIR/lspci.tmp
-fi
+	if [ -e /proc/asound/modules ]; then
+		while read -r _ mod; do
+			echo "$mod"
+		done </proc/asound/modules >"$TEMPDIR/alsamodules.tmp"
+	else
+		echo > "$TEMPDIR/alsamodules.tmp"
+	fi
+	cat /proc/asound/cards > "$TEMPDIR/alsacards.tmp"
+	lspci | grep -i "multi\|audio" > "$TEMPDIR/lspci.tmp"
 
-#Check for HDA-Intel cards codec#*
-cat /proc/asound/card*/codec\#* > $TEMPDIR/alsa-hda-intel.tmp 2> /dev/null
+	#Check for HDA-Intel cards codec#*
+	cat /proc/asound/card*/codec\#* > "$TEMPDIR/alsa-hda-intel.tmp" 2>/dev/null
 
-#Check for AC97 cards codec
-cat /proc/asound/card*/codec97\#0/ac97\#0-0 > $TEMPDIR/alsa-ac97.tmp 2> /dev/null
-cat /proc/asound/card*/codec97\#0/ac97\#0-0+regs > $TEMPDIR/alsa-ac97-regs.tmp 2> /dev/null
+	#Check for AC97 cards codec
+	cat /proc/asound/card*/codec97\#0/ac97\#0-0 > "$TEMPDIR/alsa-ac97.tmp" 2>/dev/null
+	cat /proc/asound/card*/codec97\#0/ac97\#0-0+regs > "$TEMPDIR/alsa-ac97-regs.tmp" 2>/dev/null
 
-#Check for USB mixer setup
-cat /proc/asound/card*/usbmixer > $TEMPDIR/alsa-usbmixer.tmp 2> /dev/null
+	#Check for USB mixer setup
+	cat /proc/asound/card*/usbmixer > "$TEMPDIR/alsa-usbmixer.tmp" 2>/dev/null
 
-#Fetch the info, and put it in $FILE in a nice readable format.
-if [[ -z $PASTEBIN ]]; then
-echo "upload=true&script=true&cardinfo=" > $FILE
-else
-echo "name=$USER&type=33&description=/tmp/alsa-info.txt&expiry=&s=Submit+Post&content=" > $FILE
-fi
-echo "!!################################" >> $FILE
-echo "!!ALSA Information Script v $SCRIPT_VERSION" >> $FILE
-echo "!!################################" >> $FILE
-echo "" >> $FILE
-echo "!!Script ran on: $TSTAMP" >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!Linux Distribution" >> $FILE
-echo "!!------------------" >> $FILE
-echo "" >> $FILE
-echo $DISTRO >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!DMI Information" >> $FILE
-echo "!!---------------" >> $FILE
-echo "" >> $FILE
-echo "Manufacturer:      $DMI_SYSTEM_MANUFACTURER" >> $FILE
-echo "Product Name:      $DMI_SYSTEM_PRODUCT_NAME" >> $FILE
-echo "Product Version:   $DMI_SYSTEM_PRODUCT_VERSION" >> $FILE
-echo "Firmware Version:  $DMI_SYSTEM_FIRMWARE_VERSION" >> $FILE
-echo "Board Vendor:      $DMI_BOARD_VENDOR" >> $FILE
-echo "Board Name:        $DMI_BOARD_NAME" >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!ACPI Device Status Information" >> $FILE
-echo "!!---------------" >> $FILE
-echo "" >> $FILE
-cat $TEMPDIR/acpidevicestatus.tmp >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!Kernel Information" >> $FILE
-echo "!!------------------" >> $FILE
-echo "" >> $FILE
-echo "Kernel release:    $KERNEL_VERSION" >> $FILE
-echo "Operating System:  $KERNEL_OS" >> $FILE
-echo "Architecture:      $KERNEL_MACHINE" >> $FILE
-echo "Processor:         $KERNEL_PROCESSOR" >> $FILE
-echo "SMP Enabled:       $KERNEL_SMP" >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!ALSA Version" >> $FILE
-echo "!!------------" >> $FILE
-echo "" >> $FILE
-echo "Driver version:     $ALSA_DRIVER_VERSION" >> $FILE
-echo "Library version:    $ALSA_LIB_VERSION" >> $FILE
-echo "Utilities version:  $ALSA_UTILS_VERSION" >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!Loaded ALSA modules" >> $FILE
-echo "!!-------------------" >> $FILE
-echo "" >> $FILE
-cat $TEMPDIR/alsamodules.tmp >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!Sound Servers on this system" >> $FILE
-echo "!!----------------------------" >> $FILE
-echo "" >> $FILE
-if [[ -n $PAINST ]];then
-[[ $(pgrep '^(.*/)?pulseaudio$') ]] && PARUNNING="Yes" || PARUNNING="No"
-echo "Pulseaudio:" >> $FILE
-echo "      Installed - Yes ($PAINST)" >> $FILE
-echo "      Running - $PARUNNING" >> $FILE
-echo "" >> $FILE
-fi
-if [[ -n $ESDINST ]];then
-[[ $(pgrep '^(.*/)?esd$') ]] && ESDRUNNING="Yes" || ESDRUNNING="No"
-echo "ESound Daemon:" >> $FILE
-echo "      Installed - Yes ($ESDINST)" >> $FILE
-echo "      Running - $ESDRUNNING" >> $FILE
-echo "" >> $FILE
-fi
-if [[ -n $ARTSINST ]];then
-[[ $(pgrep '^(.*/)?artsd$') ]] && ARTSRUNNING="Yes" || ARTSRUNNING="No"
-echo "aRts:" >> $FILE
-echo "      Installed - Yes ($ARTSINST)" >> $FILE
-echo "      Running - $ARTSRUNNING" >> $FILE
-echo "" >> $FILE
-fi
-if [[ -n $JACKINST ]];then
-[[ $(pgrep '^(.*/)?jackd$') ]] && JACKRUNNING="Yes" || JACKRUNNING="No"
-echo "Jack:" >> $FILE
-echo "      Installed - Yes ($JACKINST)" >> $FILE
-echo "      Running - $JACKRUNNING" >> $FILE
-echo "" >> $FILE
-fi
-if [[ -n $ROARINST ]];then
-[[ $(pgrep '^(.*/)?roard$') ]] && ROARRUNNING="Yes" || ROARRUNNING="No"
-echo "RoarAudio:" >> $FILE
-echo "      Installed - Yes ($ROARINST)" >> $FILE
-echo "      Running - $ROARRUNNING" >> $FILE
-echo "" >> $FILE
-fi
-if [[ -z "$PAINST" && -z "$ESDINST" && -z "$ARTSINST" && -z "$JACKINST" && -z "$ROARINST" ]];then
-echo "No sound servers found." >> $FILE
-echo "" >> $FILE
-fi
-echo "" >> $FILE
-echo "!!Soundcards recognised by ALSA" >> $FILE
-echo "!!-----------------------------" >> $FILE
-echo "" >> $FILE
-cat $TEMPDIR/alsacards.tmp >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
+	#Fetch the info, and put it in $FILE in a nice readable format.
+	{
+		if [ -z "$PASTEBIN" ]; then
+			echo "upload=true&script=true&cardinfo="
+		else
+			echo "name=$USER&type=33&description=/tmp/alsa-info.txt&expiry=&s=Submit+Post&content="
+		fi
+		echo "!!################################"
+		echo "!!ALSA Information Script v $SCRIPT_VERSION"
+		echo "!!################################"
+		echo ""
+		echo "!!Script ran on: $TSTAMP"
+		echo ""
+		echo ""
+		echo "!!Linux Distribution"
+		echo "!!------------------"
+		echo ""
+		echo "$DISTRO"
+		echo ""
+		echo ""
+		echo "!!DMI Information"
+		echo "!!---------------"
+		echo ""
+		echo "Manufacturer:      $DMI_SYSTEM_MANUFACTURER"
+		echo "Product Name:      $DMI_SYSTEM_PRODUCT_NAME"
+		echo "Product Version:   $DMI_SYSTEM_PRODUCT_VERSION"
+		echo "Firmware Version:  $DMI_SYSTEM_FIRMWARE_VERSION"
+		echo "Board Vendor:      $DMI_BOARD_VENDOR"
+		echo "Board Name:        $DMI_BOARD_NAME"
+		echo ""
+		echo ""
+		echo "!!ACPI Device Status Information"
+		echo "!!---------------"
+		echo ""
+		cat "$TEMPDIR/acpidevicestatus.tmp"
+		echo ""
+		echo ""
+		echo "!!Kernel Information"
+		echo "!!------------------"
+		echo ""
+		echo "Kernel release:    $KERNEL_VERSION"
+		echo "Operating System:  $KERNEL_OS"
+		echo "Architecture:      $KERNEL_MACHINE"
+		echo "Processor:         $KERNEL_PROCESSOR"
+		echo "SMP Enabled:       $KERNEL_SMP"
+		echo ""
+		echo ""
+		echo "!!ALSA Version"
+		echo "!!------------"
+		echo ""
+		echo "Driver version:     $ALSA_DRIVER_VERSION"
+		echo "Library version:    $ALSA_LIB_VERSION"
+		echo "Utilities version:  $ALSA_UTILS_VERSION"
+		echo ""
+		echo ""
+		echo "!!Loaded ALSA modules"
+		echo "!!-------------------"
+		echo ""
+		cat "$TEMPDIR/alsamodules.tmp"
+		echo ""
+		echo ""
+		echo "!!Sound Servers on this system"
+		echo "!!----------------------------"
+		echo ""
+		if [ -n "$PAINST" ];then
+			[ -n "$(pgrep '^(.*/)?pulseaudio$')" ] && PARUNNING="Yes" || PARUNNING="No"
+			echo "Pulseaudio:"
+			echo "      Installed - Yes ($PAINST)"
+			echo "      Running - $PARUNNING"
+			echo ""
+		fi
+		if [ -n "$ESDINST" ];then
+			[ -n "$(pgrep '^(.*/)?esd$')" ] && ESDRUNNING="Yes" || ESDRUNNING="No"
+			echo "ESound Daemon:"
+			echo "      Installed - Yes ($ESDINST)"
+			echo "      Running - $ESDRUNNING"
+			echo ""
+		fi
+		if [ -n "$ARTSINST" ];then
+			[ -n "$(pgrep '^(.*/)?artsd$')" ] && ARTSRUNNING="Yes" || ARTSRUNNING="No"
+			echo "aRts:"
+			echo "      Installed - Yes ($ARTSINST)"
+			echo "      Running - $ARTSRUNNING"
+			echo ""
+		fi
+		if [ -n "$JACKINST" ];then
+			[ -n "$(pgrep '^(.*/)?jackd$')" ] && JACKRUNNING="Yes" || JACKRUNNING="No"
+			echo "Jack:"
+			echo "      Installed - Yes ($JACKINST)"
+			echo "      Running - $JACKRUNNING"
+			echo ""
+		fi
+		if [ -n "$ROARINST" ];then
+			[ -n "$(pgrep '^(.*/)?roard$')" ] && ROARRUNNING="Yes" || ROARRUNNING="No"
+			echo "RoarAudio:"
+			echo "      Installed - Yes ($ROARINST)"
+			echo "      Running - $ROARRUNNING"
+			echo ""
+		fi
+		if [ -z "${PAINST}${ESDINST}${ARTSINST}${JACKINST}${ROARINST}" ];then
+			echo "No sound servers found."
+			echo ""
+		fi
+		echo ""
+		echo "!!Soundcards recognised by ALSA"
+		echo "!!-----------------------------"
+		echo ""
+		cat "$TEMPDIR/alsacards.tmp"
+		echo ""
+		echo ""
 
-if [[ ! -z "$LSPCI" ]]; then
-echo "!!PCI Soundcards installed in the system" >> $FILE
-echo "!!--------------------------------------" >> $FILE
-echo "" >> $FILE
-cat $TEMPDIR/lspci.tmp >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!Advanced information - PCI Vendor/Device/Subsystem ID's" >> $FILE
-echo "!!-------------------------------------------------------" >> $FILE
-echo "" >> $FILE
-lspci -vvn |grep -A1 040[1-3] >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-fi
+		if [ -n "$LSPCI" ]; then
+			echo "!!PCI Soundcards installed in the system"
+			echo "!!--------------------------------------"
+			echo ""
+			cat "$TEMPDIR/lspci.tmp"
+			echo ""
+			echo ""
+			echo "!!Advanced information - PCI Vendor/Device/Subsystem ID's"
+			echo "!!-------------------------------------------------------"
+			echo ""
+			lspci -vvn | grep -A1 '040[1-3]'
+			echo ""
+			echo ""
+		fi
 
-if [ "$SNDOPTIONS" ]
-then
-echo "!!Modprobe options (Sound related)" >> $FILE
-echo "!!--------------------------------" >> $FILE
-echo "" >> $FILE
-modprobe -c|sed -n 's/^options \(snd[-_][^ ]*\)/\1:/p' >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-fi
+		if [ -n "$SNDOPTIONS" ]; then
+			echo "!!Modprobe options (Sound related)"
+			echo "!!--------------------------------"
+			echo ""
+			modprobe -c | sed -n 's/^options \(snd[-_][^ ]*\)/\1:/p'
+			echo ""
+			echo ""
+		fi
 
-if [ -d "$SYSFS" ]; then
-	echo "!!Loaded sound module options" >> $FILE
-	echo "!!---------------------------" >> $FILE
-	echo "" >> $FILE
-	for mod in $(cat /proc/asound/modules | awk '{ print $2 }'); do
-		echo "!!Module: $mod" >> $FILE
-		for params in $(echo $SYSFS/module/$mod/parameters/*); do
-			echo -ne "\t"
-			value=$(cat $params)
-			echo "$params : $value" | sed 's:.*/::'
-		done >> $FILE
-		echo "" >> $FILE
-	done
-	echo "" >> $FILE
-fi
+		if [ -d "$SYSFS" ]; then
+			echo "!!Loaded sound module options"
+			echo "!!---------------------------"
+			echo ""
+			if [ -e /proc/asound/modules ]; then
+				while read -r _ mod; do
+					echo "!!Module: $mod"
+					for params in "$SYSFS/module/$mod/parameters/"*; do
+						printf '\t'
+						value=$(cat "$params")
+						echo "$params : $value" | sed 's:.*/::'
+					done
+					echo ""
+				done </proc/asound/modules
+			fi
+			echo ""
+		fi
 
-if [ -s "$TEMPDIR/alsa-hda-intel.tmp" ]; then
-	echo "!!HDA-Intel Codec information" >> $FILE
-	echo "!!---------------------------" >> $FILE
-	echo "--startcollapse--" >> $FILE
-	echo "" >> $FILE
-	cat $TEMPDIR/alsa-hda-intel.tmp >> $FILE
-	echo "--endcollapse--" >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
-fi
+		if [ -s "$TEMPDIR/alsa-hda-intel.tmp" ]; then
+			echo "!!HDA-Intel Codec information"
+			echo "!!---------------------------"
+			echo "--startcollapse--"
+			echo ""
+			cat "$TEMPDIR/alsa-hda-intel.tmp"
+			echo "--endcollapse--"
+			echo ""
+			echo ""
+		fi
 
-if [ -s "$TEMPDIR/alsa-ac97.tmp" ]; then
-        echo "!!AC97 Codec information" >> $FILE
-        echo "!!----------------------" >> $FILE
-        echo "--startcollapse--" >> $FILE
-        echo "" >> $FILE
-        cat $TEMPDIR/alsa-ac97.tmp >> $FILE
-        echo "" >> $FILE
-        cat $TEMPDIR/alsa-ac97-regs.tmp >> $FILE
-        echo "--endcollapse--" >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
-fi
+		if [ -s "$TEMPDIR/alsa-ac97.tmp" ]; then
+			echo "!!AC97 Codec information"
+			echo "!!----------------------"
+			echo "--startcollapse--"
+			echo ""
+			cat "$TEMPDIR/alsa-ac97.tmp"
+			echo ""
+			cat "$TEMPDIR/alsa-ac97-regs.tmp"
+			echo "--endcollapse--"
+			echo ""
+			echo ""
+		fi
 
-if [ -s "$TEMPDIR/alsa-usbmixer.tmp" ]; then
-        echo "!!USB Mixer information" >> $FILE
-        echo "!!---------------------" >> $FILE
-        echo "--startcollapse--" >> $FILE
-        echo "" >> $FILE
-        cat $TEMPDIR/alsa-usbmixer.tmp >> $FILE
-        echo "--endcollapse--" >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
-fi
+		if [ -s "$TEMPDIR/alsa-usbmixer.tmp" ]; then
+			echo "!!USB Mixer information"
+			echo "!!---------------------"
+			echo "--startcollapse--"
+			echo ""
+			cat "$TEMPDIR/alsa-usbmixer.tmp"
+			echo "--endcollapse--"
+			echo ""
+			echo ""
+		fi
+	} > "$FILE"
 
-#If no command line options are specified, then run as though --with-all was specified
-if [ -z "$1" ]; then
-	update
-	pbcheck	
-fi
-
-fi # proceed
+	#If no command line options are specified, then run as though --with-all was specified
+	if [ -z "$1" ]; then
+		update
+		pbcheck
+	fi
+fi # PROCEED
 
 #loop through command line arguments, until none are left.
-if [ -n "$1" ]; then
-	until [ -z "$1" ]
-	do
+while [ -n "$1" ]; do
 	case "$1" in
 		--pastebin)
-		        update
-        		pbcheck
+			update
+			pbcheck
 			;;
 		--update)
 			update
@@ -716,31 +713,30 @@ if [ -n "$1" ]; then
 			;;
 		--with-configs)
 			WITHALL="no"
-			if [[ -e $HOME/.asoundrc ]] || [[ -e /etc/asound.conf ]]
-			then
-				echo "!!ALSA configuration files" >> $FILE
-				echo "!!------------------------" >> $FILE
-				echo "" >> $FILE
+			if [ -e "$HOME/.asoundrc" ] || [ -e /etc/asound.conf ]; then
+				{
+					echo "!!ALSA configuration files"
+					echo "!!------------------------"
+					echo ""
 
-				#Check for ~/.asoundrc
-				if [[ -e $HOME/.asoundrc ]]
-				then
-					echo "!!User specific config file ($HOME/.asoundrc)" >> $FILE
-					echo "" >> $FILE
-					cat $HOME/.asoundrc >> $FILE
-					echo "" >> $FILE
-					echo "" >> $FILE
-				fi
+					#Check for ~/.asoundrc
+					if [ -e "$HOME/.asoundrc" ]; then
+						echo "!!User specific config file ($HOME/.asoundrc)"
+						echo ""
+						cat "$HOME/.asoundrc"
+						echo ""
+						echo ""
+					fi
 
-				#Check for /etc/asound.conf
-				if [[ -e /etc/asound.conf ]]
-				then
-					echo "!!System wide config file (/etc/asound.conf)" >> $FILE
-					echo "" >> $FILE
-					cat /etc/asound.conf >> $FILE
-					echo "" >> $FILE
-					echo "" >> $FILE
-				fi
+					#Check for /etc/asound.conf
+					if [ -e /etc/asound.conf ]; then
+						echo "!!System wide config file (/etc/asound.conf)"
+						echo ""
+						cat /etc/asound.conf
+						echo ""
+						echo ""
+					fi
+				} >> "$FILE"
 			fi
 			;;
 		--stdout)
@@ -748,8 +744,8 @@ if [ -n "$1" ]; then
 			if [ -z "$WITHALL" ]; then
 				withall
 			fi
-			cat $FILE
-			rm $FILE
+			cat "$FILE"
+			rm "$FILE"
 			;;
 		--about)
 			echo "Written/Tested by the following users of #alsa on irc.freenode.net:"
@@ -770,7 +766,7 @@ if [ -n "$1" ]; then
 			echo "	--with-amixer (includes the output of amixer)"
 			echo "	--with-alsactl (includes the output of alsactl)"
 			echo "	--with-configs (includes the output of ~/.asoundrc and"
-			echo "	    /etc/asound.conf if they exist)" 
+			echo "	    /etc/asound.conf if they exist)"
 			echo "	--with-devices (shows the device nodes in /dev/snd/)"
 			echo "	--with-dmesg (shows the ALSA/HDA kernel messages)"
 			echo ""
@@ -788,9 +784,8 @@ if [ -n "$1" ]; then
 			exit 0
 			;;
 	esac
-	shift 1
-	done
-fi
+	shift
+done
 
 if [ "$PROCEED" = "no" ]; then
 	exit 1
@@ -804,163 +799,156 @@ if [ "$UPLOAD" = "ask" ]; then
 	if [ -n "$DIALOG" ]; then
 		dialog --backtitle "$BGTITLE" --title "Information collected" --yes-label " UPLOAD / SHARE " --no-label " SAVE LOCALLY " --defaultno --yesno "\n\nAutomatically upload ALSA information to $WWWSERVICE?" 10 80
 		DIALOG_EXIT_CODE=$?
-		if [ $DIALOG_EXIT_CODE != 0 ]; then
-			UPLOAD="no"
-		else
+		if [ "$DIALOG_EXIT_CODE" = 0 ]; then
 			UPLOAD="yes"
+		else
+			UPLOAD="no"
 		fi
 	else
-		echo -n "Automatically upload ALSA information to $WWWSERVICE? [y/N] : "
-		read -e CONFIRM
-		if [ "$CONFIRM" != "y" ]; then
-			UPLOAD="no"
-		else
+		printf 'Automatically upload ALSA information to %s? [y/N] : ' "$WWWSERVICE"
+		read -r CONFIRM
+		if [ "$CONFIRM" = "y" ]; then
 			UPLOAD="yes"
+		else
+			UPLOAD="no"
 		fi
 	fi
 
 fi
 
 if [ "$UPLOAD" = "no" ]; then
-
 	if [ -z "$TOSTDOUT" ]; then
-		mv -f $FILE $NFILE || exit 1
+		mv -f "$FILE" "$NFILE" || exit 1
 		KEEP_OUTPUT="yes"
 	fi
 
-	if [[ -n $DIALOG ]]
-	then
-		if [[ -n $PBERROR ]]; then
+	if [ -n "$DIALOG" ]; then
+		if [ -n "$PBERROR" ]; then
 			dialog --backtitle "$BGTITLE" --title "Information collected" --msgbox "An error occurred while contacting the $WWWSERVICE.\n Your information was NOT automatically uploaded.\n\nYour ALSA information is in $NFILE" 10 100
 		else
 			dialog --backtitle "$BGTITLE" --title "Information collected" --msgbox "\n\nYour ALSA information is in $NFILE" 10 60
 		fi
 	else
 		echo
-
-		if [[ -n $PBERROR ]]; then
+		if [ -n "$PBERROR" ]; then
 			echo "An error occurred while contacting the $WWWSERVICE."
 			echo "Your information was NOT automatically uploaded."
 			echo ""
 			echo "Your ALSA information is in $NFILE"
 			echo ""
-		else
-			if [ -z "$TOSTDOUT" ]; then
-				echo ""
-				echo "Your ALSA information is in $NFILE"
-				echo ""
-			fi
+		elif [ -z "$TOSTDOUT" ]; then
+			echo ""
+			echo "Your ALSA information is in $NFILE"
+			echo ""
 		fi
 	fi
 
 	exit
-
 fi # UPLOAD
 
 # Test that wget is installed, and supports --post-file. Upload $FILE if it does, and prompt user to upload file if it does not.
-if [[ -n "${WGET}" ]] && [[ -x "${WGET}" ]] && [[ $(wget --help | grep post-file) ]]
-then
+if wget --help 2>&1 | grep -q post-file; then
+	if [ -n "$DIALOG" ]; then
+		if [ -z "$PASTEBIN" ]; then
+			wget -O - --tries=5 --timeout=60 --post-file="$FILE" "http://www.alsa-project.org/cardinfo-db/" >"$TEMPDIR/wget.tmp" 2>&1 || echo "Upload failed; exit"
+			{
+				for i in 10 20 30 40 50 60 70 80 90; do
+					echo $i
+					sleep 0.2
+				done
+				echo
+			} | dialog --backtitle "$BGTITLE" --guage "Uploading information to www.alsa-project.org ..." 6 70 0
+		else
+			wget -O - --tries=5 --timeout=60 --post-file="$FILE" "http://pastebin.ca/quiet-paste.php?api=$PASTEBINKEY&encrypt=t&encryptpw=blahblah" >"$TEMPDIR/wget.tmp" 2>&1 || echo "Upload failed; exit"
+			{
+				for i in 10 20 30 40 50 60 70 80 90; do
+					echo $i
+					sleep 0.2
+				done
+				echo
+			} | dialog --backtitle "$BGTITLE" --guage "Uploading information to www.pastebin.ca ..." 6 70 0
+		fi
 
-if [[ -n $DIALOG ]]
-then
+		dialog --backtitle "$BGTITLE" --title "Information uploaded" --yesno "Would you like to see the uploaded information?" 5 100
+		DIALOG_EXIT_CODE=$?
+		if [ "$DIALOG_EXIT_CODE" = 0 ]; then
+			grep -v "alsa-info.txt" "$FILE" > "$TEMPDIR/uploaded.txt"
+			dialog --backtitle "$BGTITLE" --textbox "$TEMPDIR/uploaded.txt" 0 0
+		fi
 
-if [[ -z $PASTEBIN ]]; then
-	wget -O - --tries=5 --timeout=60 --post-file=$FILE "http://www.alsa-project.org/cardinfo-db/" &>$TEMPDIR/wget.tmp || echo "Upload failed; exit"
-	{ for i in 10 20 30 40 50 60 70 80 90; do
-		echo $i
-		sleep 0.2
-	done
-	echo; } |dialog --backtitle "$BGTITLE" --guage "Uploading information to www.alsa-project.org ..." 6 70 0
-else
-	wget -O - --tries=5 --timeout=60 --post-file=$FILE "http://pastebin.ca/quiet-paste.php?api=$PASTEBINKEY&encrypt=t&encryptpw=blahblah" &>$TEMPDIR/wget.tmp || echo "Upload failed; exit"
-	{ for i in 10 20 30 40 50 60 70 80 90; do
-		echo $i
-		sleep 0.2
-	done
-	echo; } |dialog --backtitle "$BGTITLE" --guage "Uploading information to www.pastebin.ca ..." 6 70 0
-fi
+		clear
 
-dialog --backtitle "$BGTITLE" --title "Information uploaded" --yesno "Would you like to see the uploaded information?" 5 100 
-DIALOG_EXIT_CODE=$?
-if [ $DIALOG_EXIT_CODE = 0 ]; then
-	grep -v "alsa-info.txt" $FILE > $TEMPDIR/uploaded.txt
-	dialog --backtitle "$BGTITLE" --textbox $TEMPDIR/uploaded.txt 0 0
-fi
+	else # no dialog
+		if [ -z "$PASTEBIN" ]; then
+			printf 'Uploading information to www.alsa-project.org ... '
+			wget -O - --tries=5 --timeout=60 --post-file="$FILE" http://www.alsa-project.org/cardinfo-db/ >"$TEMPDIR/wget.tmp" 2>&1 &
+		else
+			printf 'Uploading information to www.pastebin.ca ... '
+			wget -O - --tries=5 --timeout=60 --post-file="$FILE" "http://pastebin.ca/quiet-paste.php?api=$PASTEBINKEY" >"$TEMPDIR/wget.tmp" 2>&1 &
+		fi
 
-clear
+		#Progess spinner for wget transfer.
+		i=1
+		printf ' '
+		while kill -0 "$!"; do # run while backgrounded wget is running
+			case "$(((i += 1) % 4))" in
+				0)  printf '\b/';;
+				1)  printf '\b-';;
+				2)  printf '\b\\';;
+				3)  printf '\b|';;
+			esac
+		done
 
-# no dialog
-else
+		printf '\b Done!\n'
+		echo ""
+	fi # dialog
 
-if [[ -z $PASTEBIN ]]; then
-	echo -n "Uploading information to www.alsa-project.org ... " 
-	wget -O - --tries=5 --timeout=60 --post-file=$FILE http://www.alsa-project.org/cardinfo-db/ &>$TEMPDIR/wget.tmp &
-else
-	echo -n "Uploading information to www.pastebin.ca ... " 
-	wget -O - --tries=5 --timeout=60 --post-file=$FILE http://pastebin.ca/quiet-paste.php?api=$PASTEBINKEY &>$TEMPDIR/wget.tmp &
-fi
-
-#Progess spinner for wget transfer.
-i=1
-sp="/-\|"
-echo -n ' '
-while pgrep wget &>/dev/null
-do
-	echo -en "\b${sp:i++%${#sp}:1}"
-done
-
-echo -e "\b Done!"
-echo ""
-
-fi # dialog
-
-# See if tput is available, and use it if it is.
-if [ -n "$TPUT" ]; then
-	if [[ -z $PASTEBIN ]]; then
-		FINAL_URL=$(tput setaf 1; grep "SUCCESS:" $TEMPDIR/wget.tmp | cut -d ' ' -f 2 ; tput sgr0)
+	# See if tput is available, and use it if it is.
+	if [ -n "$TPUT" ]; then
+		if [ -z "$PASTEBIN" ]; then
+			FINAL_URL=$(tput setaf 1; grep "SUCCESS:" "$TEMPDIR/wget.tmp" | cut -d ' ' -f 2 ; tput sgr0)
+		else
+			FINAL_URL=$(tput setaf 1; grep "SUCCESS:" "$TEMPDIR/wget.tmp" | sed -n 's/.*\:\([0-9]\+\).*/http:\/\/pastebin.ca\/\1/p'; tput sgr0)
+		fi
 	else
-		FINAL_URL=$(tput setaf 1; grep "SUCCESS:" $TEMPDIR/wget.tmp | sed -n 's/.*\:\([0-9]\+\).*/http:\/\/pastebin.ca\/\1/p'; tput sgr0)
+		if [ -z "$PASTEBIN" ]; then
+			FINAL_URL=$(grep "SUCCESS:" "$TEMPDIR/wget.tmp" | cut -d ' ' -f 2)
+		else
+			FINAL_URL=$(grep "SUCCESS:" "$TEMPDIR/wget.tmp" | sed -n 's/.*\:\([0-9]\+\).*/http:\/\/pastebin.ca\/\1/p')
+		fi
 	fi
-else
-	if [[ -z $PASTEBIN ]]; then
-		FINAL_URL=$(grep "SUCCESS:" $TEMPDIR/wget.tmp | cut -d ' ' -f 2)
-	else
-		FINAL_URL=$(grep "SUCCESS:" $TEMPDIR/wget.tmp | sed -n 's/.*\:\([0-9]\+\).*/http:\/\/pastebin.ca\/\1/p')
-	fi
-fi
 
-# Output the URL of the uploaded file.	
-echo "Your ALSA information is located at $FINAL_URL"
-echo "Please inform the person helping you."
-echo ""
+	# Output the URL of the uploaded file.
+	echo "Your ALSA information is located at $FINAL_URL"
+	echo "Please inform the person helping you."
+	echo ""
 
 # We couldnt find a suitable wget, so tell the user to upload manually.
 else
-	mv -f $FILE $NFILE || exit 1
+	mv -f "$FILE" "$NFILE" || exit 1
 	KEEP_OUTPUT="yes"
-	if [[ -z $DIALOG ]]
-	then
-		if [[ -z $PASTEBIN ]]; then
-		echo ""
-		echo "Could not automatically upload output to http://www.alsa-project.org"
-		echo "Possible reasons are:"
-		echo "    1. Couldnt find 'wget' in your PATH"
-		echo "    2. Your version of wget is less than 1.8.2"
-		echo ""
-		echo "Please manually upload $NFILE to http://www.alsa-project.org/cardinfo-db/ and submit your post."
-		echo ""
+	if [ -z "$DIALOG" ]; then
+		if [ -z "$PASTEBIN" ]; then
+			echo ""
+			echo "Could not automatically upload output to http://www.alsa-project.org"
+			echo "Possible reasons are:"
+			echo "    1. Couldnt find 'wget' in your PATH"
+			echo "    2. Your version of wget is less than 1.8.2"
+			echo ""
+			echo "Please manually upload $NFILE to http://www.alsa-project.org/cardinfo-db/ and submit your post."
+			echo ""
 		else
-		echo ""
-		echo "Could not automatically upload output to http://www.pastebin.ca"
-		echo "Possible reasons are:"
-		echo "    1. Couldnt find 'wget' in your PATH"
-		echo "    2. Your version of wget is less than 1.8.2"
-		echo ""
-		echo "Please manually upload $NFILE to http://www.pastebin.ca/upload.php and submit your post."
-		echo ""
+			echo ""
+			echo "Could not automatically upload output to http://www.pastebin.ca"
+			echo "Possible reasons are:"
+			echo "    1. Couldnt find 'wget' in your PATH"
+			echo "    2. Your version of wget is less than 1.8.2"
+			echo ""
+			echo "Please manually upload $NFILE to http://www.pastebin.ca/upload.php and submit your post."
+			echo ""
 		fi
 	else
-		if [[ -z $PASTEBIN ]]; then
+		if [ -z "$PASTEBIN" ]; then
 			dialog --backtitle "$BGTITLE" --msgbox "Could not automatically upload output to http://www.alsa-project.org.\nPossible reasons are:\n\n    1. Couldn't find 'wget' in your PATH\n    2. Your version of wget is less than 1.8.2\n\nPlease manually upload $NFILE to http://www.alsa-project,org/cardinfo-db/ and submit your post." 25 100
 		else
 			dialog --backtitle "$BGTITLE" --msgbox "Could not automatically upload output to http://www.pastebin.ca.\nPossible reasons are:\n\n    1. Couldn't find 'wget' in your PATH\n    2. Your version of wget is less than 1.8.2\n\nPlease manually upload $NFILE to http://www.pastebin.ca/upload.php and submit your post." 25 100


### PR DESCRIPTION
Please review and squash this commit into your merge request. It fixes these issues with the commit:

- detection of sysfs
- parsing of ALSA driver version

and also adds the following changes:

- replaces variable assignments from 'cat' (called inside a subshell) with 'read'
- simplifies conditionals to reduce nesting and avoid redundancy

Thanks!